### PR TITLE
MockNSURLConnection sending cached response to delegate

### DIFF
--- a/Classes/Mock/GHMockNSURLConnection.m
+++ b/Classes/Mock/GHMockNSURLConnection.m
@@ -104,6 +104,8 @@ NSString *const GHMockNSURLConnectionException = @"GHMockNSURLConnectionExceptio
 	[response setStatusCode:statusCode];
 	[self receiveResponse:response afterDelay:delay];
 	[self receiveData:data afterDelay:delay];
+  NSCachedURLResponse *cachedResponse = [[NSCachedURLResponse alloc] initWithResponse:response data:data];
+  [delegate_ connection:(NSURLConnection *)self willCacheResponse:cachedResponse];
 	[self finishAfterDelay:delay];	
 }
 


### PR DESCRIPTION
Support unit tests for caching - manually send the delegate message for caching
