### PR TITLE
added GHTestOptionIgnoreViewTestNotification

### DIFF
--- a/Classes-iOS/GHUnitIOSViewController.m
+++ b/Classes-iOS/GHUnitIOSViewController.m
@@ -129,7 +129,7 @@ NSString *const GHUnitFilterKey = @"Filter";
   userDidDrag_ = NO; // Reset drag status
   view_.statusLabel.textColor = [UIColor blackColor];
   view_.statusLabel.text = @"Starting tests...";
-  [self.dataSource run:self inParallel:NO options:0];
+  [self.dataSource run:self inParallel:NO options:GHTestOptionIgnoreViewTestNotification];
 }
 
 - (void)cancel {

--- a/Classes/GHTest/GHTest.h
+++ b/Classes/GHTest/GHTest.h
@@ -57,6 +57,7 @@ typedef NS_ENUM(NSInteger, GHTestStatus) {
 enum {
   GHTestOptionReraiseExceptions = 1 << 0, // Allows exceptions to be raised (so you can trigger the debugger)
   GHTestOptionForceSetUpTearDownClass = 1 << 1, // Runs setUpClass/tearDownClass for this (each) test; Used when re-running a single test in a group
+  GHTestOptionIgnoreViewTestNotification = 1 << 2, // Test will not setup an observer for GHUnitViewTestPassNotificiation
 };
 typedef NSInteger GHTestOptions;
 

--- a/Classes/GHTest/GHTest.m
+++ b/Classes/GHTest/GHTest.m
@@ -216,7 +216,10 @@ exception=exception_, status=status_, log=log_, identifier=identifier_, disabled
 
   BOOL reraiseExceptions = ((options & GHTestOptionReraiseExceptions) == GHTestOptionReraiseExceptions);
   NSException *exception = nil;
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_viewTestPassedNotification:) name:GHUnitViewTestPassNotificiation object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:GHUnitViewTestPassNotificiation object:nil];
+  if ((options & GHTestOptionIgnoreViewTestNotification) != GHTestOptionIgnoreViewTestNotification) {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_viewTestPassedNotification:) name:GHUnitViewTestPassNotificiation object:nil];
+  }
   [GHTesting runTestWithTarget:target_ selector:selector_ exception:&exception interval:&interval_ reraiseExceptions:reraiseExceptions];
   [[NSNotificationCenter defaultCenter] removeObserver:self name:GHUnitViewTestPassNotificiation object:nil];
   exception_ = exception;

--- a/Classes/GHTest/GHTestRunner.m
+++ b/Classes/GHTest/GHTestRunner.m
@@ -92,6 +92,7 @@ operationQueue=operationQueue_;
   GHTestSuite *suite = [GHTestSuite suiteFromEnv];
   GHTestRunner *runner = [GHTestRunner runnerForSuite:suite];
   if (getenv("GHUNIT_RERAISE")) runner.options = GHTestOptionReraiseExceptions;
+  runner.options |= GHTestOptionIgnoreViewTestNotification;
   return runner;
 } 
 

--- a/GHUnitYelpFork.podspec
+++ b/GHUnitYelpFork.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "GHUnitYelpFork"
-  s.version      = "1.0.5"
+  s.version      = "1.1.0"
   s.summary      = "GHUnit is a test framework for Mac OS X and iOS. It can be used standalone or with other testing frameworks like SenTestingKit or GTM."
   s.homepage     = "http://github.com/Yelp/gh-unit"
   s.license      = "MIT"


### PR DESCRIPTION
This adds this new option to have tests ignore the view test passed notification. This way you can avoid saving the image for memory savings purposes. By default, this option is enabled for the cases where the whole test suite will be run: command line and the "Run" button.