### PR TITLE
Only reload the actual test row, instead of the whole table

### DIFF
--- a/Classes-iOS/GHUnitIOSViewController.m
+++ b/Classes-iOS/GHUnitIOSViewController.m
@@ -182,8 +182,10 @@ NSString *const GHUnitFilterKey = @"Filter";
 }
 
 - (void)reloadTest:(id<GHTest>)test {
-  [view_.tableView reloadData];
-  if (!userDidDrag_ && !dataSource_.isEditing && ![test isDisabled] 
+  NSIndexPath *indexPath = [dataSource_ indexPathToTest:test];
+  if (!indexPath) return;
+  [view_.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+  if (!userDidDrag_ && !dataSource_.isEditing && ![test isDisabled]
       && [test status] == GHTestStatusRunning && ![test conformsToProtocol:@protocol(GHTestGroup)]) 
     [self scrollToTest:test];
 }


### PR DESCRIPTION
If you have a lot of tests, this makes running tests faster, since you don't have to reload the whole table each time a test updates.